### PR TITLE
Update target URL for ecb proxy in vite.config.ts to new data API endpoint

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/proxy/ecb': {
-        target: 'https://sdw-wsrest.ecb.europa.eu',
+        target: 'https://data-api.ecb.europa.eu',
         changeOrigin: true,
         secure: true,
         followRedirects: true,


### PR DESCRIPTION
Hi Sam. The old URL being present in the vite config was breaking the tool in my local (I believe). Have updated.